### PR TITLE
Add support for html string components and other small maintenance

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,6 @@
   "extends": "eslint-config-airbnb",
   "env": {
     "browser": true,
-    "mocha": true,
     "node": true
   },
   "rules": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "babel-preset-es2015-loose": "^6.1.4",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
-    "babelify": "^6.2.0",
     "chai": "^3.3.0",
     "eslint": "^1.1.0",
     "eslint-config-airbnb": "0.0.8",

--- a/spec/.eslintrc
+++ b/spec/.eslintrc
@@ -1,0 +1,9 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "rules": {
+    "react/no-multi-comp": 0
+  }
+}
+

--- a/spec/getDislplayNameSpec.js
+++ b/spec/getDislplayNameSpec.js
@@ -22,7 +22,7 @@ describe('getDisplayName', () => {
     expect(getDisplayName(Simple)).to.equal('Simple');
   });
   it('returns display name for a stateless component', () => {
-    const Simple = (props) => <div></div>
+    const Simple = () => <div></div>;
 
     expect(getDisplayName(Simple)).to.equal('Simple');
   });
@@ -50,7 +50,7 @@ describe('getDisplayName', () => {
         }
       }
       return Container;
-    }
+    };
 
     class HelloWorld extends Component {
       render() {
@@ -64,5 +64,5 @@ describe('getDisplayName', () => {
 
     expect(getDisplayName(HelloWorldPrime)).to.equal('Container(HelloWorld)');
     expect(HelloWorldPrime.displayName).to.equal('Container(HelloWorld)');
-  })
+  });
 });

--- a/spec/getDislplayNameSpec.js
+++ b/spec/getDislplayNameSpec.js
@@ -21,6 +21,9 @@ describe('getDisplayName', () => {
     }
     expect(getDisplayName(Simple)).to.equal('Simple');
   });
+  it('returns display name of html string component', () => {
+    expect(getDisplayName('input')).to.equal('input');
+  });
   it('returns display name for a stateless component', () => {
     const Simple = () => <div></div>;
 

--- a/src/getDisplayName.js
+++ b/src/getDisplayName.js
@@ -1,5 +1,5 @@
 const getDisplayName = Component => (
-  Component.displayName || Component.name || 'Component'
+  Component.displayName || Component.name || (typeof Component === 'string' ? Component : 'Component')
 );
 
 export default getDisplayName;


### PR DESCRIPTION
`React.createElement` supports receiving strings, such as `"div"` or `"input"`, which represent html tags.
In the case a string is passed to a HoC, return the string as is.
Additionally, fixed the linter for the specs and removed unused dependencies.