### PR TITLE
Typescript support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,12 @@
   "version": "0.2.3",
   "description": "utility to return a react components display name",
   "main": "./lib/getDisplayName.js",
+  "typings": "./lib/getDisplayName.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
-    "build:lib": "mkdirp lib && babel src -d lib",
+    "build:lib": "mkdirp lib && babel src -d lib && cpy src/*.d.ts lib",
     "build:spec": "mkdirp lib/spec && babel spec -d lib/spec",
     "build": "npm run clean && npm run lint && npm run build:lib && npm run build:spec",
     "clean": "rimraf lib",
@@ -37,6 +38,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-2": "^6.24.1",
     "chai": "^4.1.0",
+    "cpy-cli": "^1.0.1",
     "eslint": "4.3.0",
     "eslint-plugin-import": "^2.2.0",
     "eslint-plugin-react": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/jurassix/react-display-name#readme",
   "devDependencies": {
+    "@types/react": "*",
     "babel-cli": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-preset-env": "^1.6.0",

--- a/src/getDisplayName.d.ts
+++ b/src/getDisplayName.d.ts
@@ -1,0 +1,6 @@
+declare module 'react-display-name' {
+  import * as React from 'react';
+  export default function getDisplayName(
+    Component: React.ComponentType<any> | string
+  ): string;
+}


### PR DESCRIPTION
Hello. I noticed there was not a definition on DefinitelyTyped for this package. I thought maybe we could add it directly to this package? I tried to follow the same conventions you used throughout the code and build process. 

If this isn't something you  are interested in adding, I will just make the PR to DefinitlyTyped instead. However, this method prevents the user from having to manually add another dependency:

`npm i -D @types/react-display-name`

Thanks!