### PR TITLE
Omit test files from package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-src
-lib/spec
-examples
-.babelrc

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./lib/getDisplayName.js",
   "typings": "./lib/getDisplayName.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "!lib/spec"
   ],
   "scripts": {
     "build:lib": "mkdirp lib && babel src -d lib && cpy src/*.d.ts lib",


### PR DESCRIPTION
Files included via the "files" config cannot be removed via .npmignore, so the "lib" entry in files was causing "lib/spec" tests to be included in the package. Removing .npmignore and relying exclusively on "files", with the addition of a negation for "lib/spec",  omits the test files.

The other entries in .npmignore are not needed since the "files" config acts as a whitelist.

`npm pack` shows that these files will be included with this change:

```
npm notice === Tarball Contents ===
npm notice 1.1kB LICENSE
npm notice 285B  lib/getDisplayName.js
npm notice 1.5kB package.json
npm notice 925B  README.md
npm notice 177B  lib/getDisplayName.d.ts
```

Fixes #12, #13 